### PR TITLE
Persist code between language switch

### DIFF
--- a/src/components/language-menu.tsx
+++ b/src/components/language-menu.tsx
@@ -11,12 +11,6 @@ import {
 	SelectValue,
 } from "./ui/select";
 
-function isCompilerLanguage(
-	language: AppLanguage,
-): language is CompilerLanguage {
-	return language !== "webd";
-}
-
 const compilerLanguagesList = [
 	...Object.values(compilerLanguages).map(({ value, label }) => ({
 		value,
@@ -25,10 +19,16 @@ const compilerLanguagesList = [
 	{ value: "webd", label: "Web Development" },
 ] as const;
 
+function isCompilerLanguage(
+	language: AppLanguage,
+): language is CompilerLanguage {
+	return language !== "webd";
+}
+
 export default function LanguageMenu() {
 	const selectedLanguage = useLanguage();
 	const { setLanguage } = useLanguageActions();
-	const { resetCodeToBoilerplate } = useCodeExecutionActions();
+	const { ensureLanguageDraft } = useCodeExecutionActions();
 
 	const handleLanguageChange = (val: string | null) => {
 		if (!val) return;
@@ -36,11 +36,11 @@ export default function LanguageMenu() {
 		const nextLanguage = val as AppLanguage;
 		if (nextLanguage === selectedLanguage) return;
 
-		setLanguage(nextLanguage);
-
 		if (isCompilerLanguage(nextLanguage)) {
-			resetCodeToBoilerplate(nextLanguage);
+			ensureLanguageDraft(nextLanguage);
 		}
+
+		setLanguage(nextLanguage);
 	};
 
 	return (

--- a/src/components/programming-editor.tsx
+++ b/src/components/programming-editor.tsx
@@ -21,14 +21,15 @@ function isCompilerLanguage(language: string): language is CompilerLanguage {
 
 export default function ProgrammingEditor() {
 	const language = useLanguage();
-	const code = useCodeExecutionCode();
 	const stdIn = useCodeExecutionStdIn();
 	const isSubmitting = useCodeExecutionIsSubmitting();
 	const { setCode, setOutput, setIsSubmitting } = useCodeExecutionActions();
 	const submitCodeFn = useServerFn(submitCodeServerFn);
+	const activeLanguage = isCompilerLanguage(language) ? language : null;
+	const code = useCodeExecutionCode(activeLanguage ?? "cpp17");
 
 	const submitCode = useCallback(async () => {
-		if (isSubmitting || !isCompilerLanguage(language)) return;
+		if (isSubmitting || !activeLanguage) return;
 
 		setIsSubmitting(true);
 
@@ -37,7 +38,7 @@ export default function ProgrammingEditor() {
 				data: {
 					script: code,
 					stdin: stdIn,
-					language,
+					language: activeLanguage,
 				},
 			});
 			setOutput({
@@ -51,8 +52,8 @@ export default function ProgrammingEditor() {
 			setIsSubmitting(false);
 		}
 	}, [
+		activeLanguage,
 		code,
-		language,
 		stdIn,
 		setOutput,
 		setIsSubmitting,
@@ -84,7 +85,14 @@ export default function ProgrammingEditor() {
 	return (
 		<div className="flex w-full flex-col gap-4 lg:h-full lg:min-h-0 lg:flex-row lg:overflow-hidden">
 			<section className="min-h-[400px] min-w-0 lg:h-full lg:min-h-0 lg:flex-1">
-				<Editor language={language} code={code} setCode={setCode} />
+				<Editor
+					language={language}
+					code={code}
+					setCode={(nextCode) => {
+						if (!activeLanguage) return;
+						setCode(activeLanguage, nextCode);
+					}}
+				/>
 			</section>
 
 			<div className="flex min-w-0 flex-col gap-4 lg:min-h-0 lg:w-[400px] xl:w-[450px]">

--- a/src/stores/code-execution-store.ts
+++ b/src/stores/code-execution-store.ts
@@ -1,73 +1,105 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import { supportedLanguages } from "@/lib/supported-languages";
-import { SubmissionOutput, SupportedLanguage } from "@/lib/types";
+import {
+	CompilerLanguage,
+	SubmissionOutput,
+	SupportedLanguage,
+} from "@/lib/types";
+
+type CodeDrafts = Partial<Record<SupportedLanguage, string>>;
 
 type CodeExecutionState = {
-	code: string;
+	codeByLanguage: CodeDrafts;
 	stdIn: string;
 	output: SubmissionOutput | null;
 	isSubmitting: boolean;
 };
 
 type CodeExecutionActions = {
-	setCode: (code: string | ((prev: string) => string)) => void;
+	setCode: (
+		language: CompilerLanguage,
+		code: string | ((prev: string) => string),
+	) => void;
 	setStdIn: (stdIn: string) => void;
 	setOutput: (output: SubmissionOutput | null) => void;
 	setIsSubmitting: (isSubmitting: boolean) => void;
-	resetCodeToBoilerplate: (language: SupportedLanguage) => void;
+	ensureLanguageDraft: (language: CompilerLanguage) => void;
+	resetCodeToBoilerplate: (language: CompilerLanguage) => void;
 };
 
-function isSupportedLanguage(language: unknown): language is SupportedLanguage {
-	return typeof language === "string" && language in supportedLanguages;
+function getBoilerplate(language: SupportedLanguage) {
+	return supportedLanguages[language]?.boilerplate ?? "";
 }
-
-const getInitialCode = () => {
-	if (typeof window === "undefined")
-		return supportedLanguages["cpp17"].boilerplate;
-
-	const persistedLanguage = localStorage.getItem("next-pen-language");
-
-	if (!persistedLanguage) {
-		return supportedLanguages["cpp17"].boilerplate;
-	}
-
-	try {
-		const parsed = JSON.parse(persistedLanguage);
-		const language = parsed?.state?.language;
-
-		// Ignore persisted values like "webd" and fall back to a runnable language.
-		if (isSupportedLanguage(language)) {
-			return supportedLanguages[language].boilerplate;
-		}
-	} catch {
-		// Ignore malformed localStorage state and keep the default boilerplate.
-	}
-
-	return supportedLanguages["cpp17"].boilerplate;
-};
 
 const useCodeExecutionStore = create<
 	CodeExecutionState & { actions: CodeExecutionActions }
->()((set) => ({
-	code: getInitialCode(),
-	stdIn: "",
-	output: null,
-	isSubmitting: false,
-	actions: {
-		setCode: (code) =>
-			set((state) => ({
-				code: typeof code === "function" ? code(state.code) : code,
-			})),
-		setStdIn: (stdIn) => set({ stdIn }),
-		setOutput: (output) => set({ output }),
-		setIsSubmitting: (isSubmitting) => set({ isSubmitting }),
-		resetCodeToBoilerplate: (language) =>
-			set({ code: supportedLanguages[language]?.boilerplate ?? "" }),
-	},
-}));
+>()(
+	persist(
+		(set) => ({
+			codeByLanguage: {},
+			stdIn: "",
+			output: null,
+			isSubmitting: false,
+			actions: {
+				setCode: (language, code) =>
+					set((state) => {
+						const previousCode =
+							state.codeByLanguage[language] ??
+							getBoilerplate(language);
 
-export const useCodeExecutionCode = () =>
-	useCodeExecutionStore((state) => state.code);
+						return {
+							codeByLanguage: {
+								...state.codeByLanguage,
+								[language]:
+									typeof code === "function"
+										? code(previousCode)
+										: code,
+							},
+						};
+					}),
+				setStdIn: (stdIn) => set({ stdIn }),
+				setOutput: (output) => set({ output }),
+				setIsSubmitting: (isSubmitting) => set({ isSubmitting }),
+				ensureLanguageDraft: (language) =>
+					set((state) => {
+						if (state.codeByLanguage[language] !== undefined) {
+							return state;
+						}
+
+						return {
+							codeByLanguage: {
+								...state.codeByLanguage,
+								[language]: getBoilerplate(language),
+							},
+						};
+					}),
+				resetCodeToBoilerplate: (language) =>
+					set((state) => ({
+						codeByLanguage: {
+							...state.codeByLanguage,
+							[language]: getBoilerplate(language),
+						},
+					})),
+			},
+		}),
+		{
+			name: "tancode-code-execution",
+			partialize: (state) => ({
+				codeByLanguage: state.codeByLanguage,
+			}),
+			merge: (persistedState, currentState) => ({
+				...currentState,
+				...(persistedState as Partial<CodeExecutionState>),
+			}),
+		},
+	),
+);
+
+export const useCodeExecutionCode = (language: CompilerLanguage) =>
+	useCodeExecutionStore(
+		(state) => state.codeByLanguage[language] ?? getBoilerplate(language),
+	);
 export const useCodeExecutionStdIn = () =>
 	useCodeExecutionStore((state) => state.stdIn);
 export const useCodeExecutionOutput = () =>

--- a/src/stores/editor-settings-store.ts
+++ b/src/stores/editor-settings-store.ts
@@ -55,7 +55,7 @@ const useEditorSettingsStore = create<
 			},
 		}),
 		{
-			name: "next-pen-editor-settings",
+			name: "tancode-editor-settings",
 			partialize: (state) => ({
 				theme: validThemeValues.includes(state.theme)
 					? state.theme

--- a/src/stores/language-store.ts
+++ b/src/stores/language-store.ts
@@ -23,7 +23,7 @@ const useLanguageStore = create<LanguageState & { actions: LanguageActions }>()(
 			},
 		}),
 		{
-			name: "next-pen-language",
+			name: "tancode-language",
 			partialize: (state) => ({ language: state.language }),
 			merge: (persistedState, currentState) => ({
 				...currentState,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -135,8 +135,8 @@
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 4px);
 
-	--font-mono: var(--font-geist);
-	--font-heading: var(--font-geist);
+	--font-mono: var(--font-jetbrains);
+	--font-heading: var(--font-jetbrains);
 
 	--radius-2xl: calc(var(--radius) * 1.8);
 	--radius-3xl: calc(var(--radius) * 2.2);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Persist code drafts per compiler language and restore them when switching, so users don’t lose work. Drafts are saved to localStorage and the editor submits using the active language only.

- New Features
  - Store code per compiler language in `tancode-code-execution` via `zustand` persist.
  - New actions: `ensureLanguageDraft(language)` and `resetCodeToBoilerplate(language)`; the language menu ensures a draft before switching.
  - Editor reads/writes code by active compiler language and submits with that language.

- Refactors
  - Renamed persistence keys: `tancode-language` and `tancode-editor-settings` (replaces `next-pen-*`); reverted mono and heading fonts to JetBrains.

<sup>Written for commit d88c1ff18f7af78bf321cc75d84fe8c4d7d75b20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

